### PR TITLE
[SS-1] Added u00a5 to JPY currency mapping

### DIFF
--- a/pytchat/processors/compatible/renderer/currency.py
+++ b/pytchat/processors/compatible/renderer/currency.py
@@ -29,6 +29,7 @@ symbols = {
     "€": {"fxtext": "EUR", "jptext": "欧・ユーロ"},
     "₹": {"fxtext": "INR", "jptext": "インド・ルピー"},
     "￥": {"fxtext": "JPY", "jptext": "日本・円"},
+    "\xa5": {"fxtext": "JPY", "jptext": "日本・円"},
     "PEN\xa0": {"fxtext": "PEN", "jptext": "ペルー・ヌエボ・ソル"},
     "ARS\xa0": {"fxtext": "ARS", "jptext": "アルゼンチン・ペソ"},
     "CLP\xa0": {"fxtext": "CLP", "jptext": "チリ・ペソ"},


### PR DESCRIPTION
# Overview
Add "\u00a5" --> "JPY" currency symbol mapping to CompatibleProcessor.

# Issue
resolves #1 

# Changes
Added mapping.
