### PR TITLE
[SS-6] Use emoji instead of alias if it's not custom one

### DIFF
--- a/pytchat/processors/compatible/renderer/base.py
+++ b/pytchat/processors/compatible/renderer/base.py
@@ -49,7 +49,8 @@ class BaseRenderer:
                 for r in runs:
                     if r:
                         if r.get('emoji'):
-                            message += r['emoji'].get('shortcuts', [''])[0]
+                            is_custom_emoji = r['emoji'].get('isCustomEmoji', False)
+                            message += r['emoji'].get('shortcuts', [''])[0] if is_custom_emoji else r['emoji'].get('emojiId')
                         else:
                             message += r.get('text', '')
         return message


### PR DESCRIPTION
# Overview
Fixed to use emoji instead of alias if it's not custom one.

# Issue
resolves #6

# Changes
- Check `isCustomEmoji` property of emoji object
- if it is `True`, use alias (`shortcuts[0]`)
- if it is `False`, use emoji (`emojiId`)