### PR TITLE
[SS-8] Fixed to set supers' amountMicros property as str (not int)

### DIFF
--- a/pytchat/processors/compatible/renderer/base.py
+++ b/pytchat/processors/compatible/renderer/base.py
@@ -49,7 +49,8 @@ class BaseRenderer:
                 for r in runs:
                     if r:
                         if r.get('emoji'):
-                            message += r['emoji'].get('shortcuts', [''])[0]
+                            is_custom_emoji = r['emoji'].get('isCustomEmoji', False)
+                            message += r['emoji'].get('shortcuts', [''])[0] if is_custom_emoji else r['emoji'].get('emojiId')
                         else:
                             message += r.get('text', '')
         return message

--- a/pytchat/processors/compatible/renderer/paidmessage.py
+++ b/pytchat/processors/compatible/renderer/paidmessage.py
@@ -22,7 +22,7 @@ class LiveChatPaidMessageRenderer(BaseRenderer):
             "hasDisplayContent": True,
             "displayMessage": amountDisplayString + " from " + authorName + ': \"' + message + '\"',
             "superChatDetails": {
-                "amountMicros": amountMicros,
+                "amountMicros": str(amountMicros),
                 "currency": currency.symbols[symbol]["fxtext"] if currency.symbols.get(symbol) else symbol,
                 "amountDisplayString": amountDisplayString,
                 "userComment": message,

--- a/pytchat/processors/compatible/renderer/paidsticker.py
+++ b/pytchat/processors/compatible/renderer/paidsticker.py
@@ -27,7 +27,7 @@ class LiveChatPaidStickerRenderer(BaseRenderer):
                     "altText": "",
                     "language": ""
                 },
-                "amountMicros": amountMicros,
+                "amountMicros": str(amountMicros),
                 "currency": currency.symbols[symbol]["fxtext"] if currency.symbols.get(symbol) else symbol,
                 "amountDisplayString": amountDisplayString,
                 "tier": 0,


### PR DESCRIPTION
# Overview
Fixed to set supers' `amountMicros` property as str (not int).

# Issue
resolves #8 

# Changes
- Fixed for super chat
- FIxed for super sticker